### PR TITLE
Add comments to the tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6496,6 +6496,19 @@
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
+    "pretty-checkbox": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pretty-checkbox/-/pretty-checkbox-3.0.3.tgz",
+      "integrity": "sha1-1JyAE6j8CO4MLW695FNGS/28Qo4="
+    },
+    "pretty-checkbox-vue": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/pretty-checkbox-vue/-/pretty-checkbox-vue-1.1.9.tgz",
+      "integrity": "sha512-45HOanzF+BUTD5prwCoNrtEFYVzWtASTIIPtPQxGCajC097pFD/9mbyjEjoTsu8Tk4/rSyA7RNk6JpFWVHpLag==",
+      "requires": {
+        "pretty-checkbox": "^3.0.3"
+      }
+    },
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
     "do-vue": "git+https://github.com/do-community/do-vue.git",
     "parcel-bundler": "^1.12.4",
+    "pretty-checkbox-vue": "^1.1.9",
     "query-string": "^6.8.3",
     "vue": "^2.6.10",
     "vue-hot-reload-api": "^2.3.3"

--- a/src/glob-tool/i18n/en/templates/app.ts
+++ b/src/glob-tool/i18n/en/templates/app.ts
@@ -4,5 +4,6 @@ export default {
     input: "Glob string",
     tests: "Test strings",
     testsSubtitle: "Enter strings here to test against the glob",
+    comments: "Comments enabled? (Start a line with '//' to write a comment when enabled)",
     oss: "This tool is {link|open-source on GitHub|https://github.com/do-community/glob-tool} under the {link|Apache-2.0|https://github.com/do-community/glob-tool/blob/master/LICENSE} license! We welcome feedback and contributions.",
 } as {[key: string]: string}

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -18,6 +18,10 @@ $header: #0071fe;
 @import "~do-bulma/src/style";
 
 .do-bulma {
+  $pretty--color-default: $primary;
+  $pretty--color-dark: $primary;
+  @import "~pretty-checkbox/src/pretty-checkbox";
+
   a.jump-link {
     text-decoration: none;
   }
@@ -88,6 +92,32 @@ $header: #0071fe;
           &.comment {
             color: $dark-grey;
             font-size: 14px;
+          }
+        }
+      }
+    }
+
+    .pretty {
+      &.p-icon {
+        font-size: 18px;
+
+        .state {
+          .icon {
+            &::before {
+              color: $panel;
+              font-size: 14px;
+            }
+          }
+
+          label {
+            color: $dark-grey;
+            font-size: 14px;
+            padding-left: $margin / 2;
+
+            &::before,
+            &::after {
+              font-size: 18px;
+            }
           }
         }
       }

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -47,7 +47,8 @@ $header: #0071fe;
         padding: ($margin / 2) $margin ($margin / 2) $left;
 
         > div {
-          line-height: 1.3;
+          font-size: 16px;
+          line-height: 21px;
           margin-left: -$left;
           padding-left: $left;
           position: relative;
@@ -70,15 +71,23 @@ $header: #0071fe;
             color: $primary;
 
             &::before {
+              color: $primary;
               content: "\f00c";
             }
           }
 
           &.miss {
+            color: $text;
+
             &::before {
               color: $dark-grey;
               content: "\f00d";
             }
+          }
+
+          &.comment {
+            color: $dark-grey;
+            font-size: 14px;
           }
         }
       }

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -67,9 +67,9 @@ limitations under the License.
                 </div>
             </div>
 
-            <PrettyCheck class="p-default p-curve p-fill p-icon" v-model="commentsEnabled">
+            <PrettyCheck v-model="commentsEnabled" class="p-default p-curve p-fill p-icon">
                 <i slot="extra" class="icon fas fa-check"></i>
-                Comments enabled? (Start a line with '//' to write a comment when enabled)
+                {{ i18n.templates.app.comments }}
             </PrettyCheck>
 
             <Help></Help>
@@ -105,13 +105,13 @@ limitations under the License.
                 commentsEnabled: null,
             }
         },
-        mounted() {
-            this.load() // Load any URL data and run an initial test
-        },
         watch: {
             commentsEnabled() {
                 this.test()
             }
+        },
+        mounted() {
+            this.load() // Load any URL data and run an initial test
         },
         methods: {
             setGlob(glob) {
@@ -131,10 +131,11 @@ limitations under the License.
             },
             setComments(comments) {
                 // Explicit false, otherwise true
-                this.$data.commentsEnabled = !(comments.toString().toLowerCase() === 'false')
+                this.$data.commentsEnabled = !(comments.toString().toLowerCase() === "false")
                 this.test()
             },
             set(glob, tests) {
+                this.$data.commentsEnabled = true
                 this.setGlob(glob)
                 this.setTests(tests)
             },
@@ -142,7 +143,7 @@ limitations under the License.
                 const parsed = queryString.parse(window.location.search)
                 if (parsed.glob) this.setGlob(parsed.glob)
                 if (parsed.tests) this.setTests(parsed.tests)
-                this.setComments(parsed.comments || 'true') // Default comments to enabled
+                this.setComments(parsed.comments || "true") // Default comments to enabled
             },
             store(glob, tests) {
                 const parsed = queryString.parse(window.location.search)
@@ -215,7 +216,7 @@ limitations under the License.
                     }
 
                     // If a comment, add the comment class
-                    if (this.$data.commentsEnabled && child.textContent.trim().startsWith('//')) {
+                    if (this.$data.commentsEnabled && child.textContent.trim().startsWith("//")) {
                         child.classList.add("comment")
                         return
                     }

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -184,17 +184,27 @@ limitations under the License.
 
                 // Run the hit/miss check
                 children.forEach(child => {
+                    // Remove all classes to start
+                    child.classList.remove("miss")
+                    child.classList.remove("hit")
+                    child.classList.remove("comment")
+
+                    // If blank, ddo nothing more
                     if (child.textContent.trim() === "") {
-                        child.classList.remove("miss")
-                        child.classList.remove("hit")
+                        return
+                    }
+
+                    // If a comment, add the comment class
+                    if (child.textContent.trim().startsWith('//')) {
+                        child.classList.add("comment")
+                        return
+                    }
+
+                    // If a match, add hit, else add miss
+                    if (minimatch(child.textContent, glob)) {
+                        child.classList.add("hit")
                     } else {
-                        if (minimatch(child.textContent, glob)) {
-                            child.classList.remove("miss")
-                            child.classList.add("hit")
-                        } else {
-                            child.classList.add("miss")
-                            child.classList.remove("hit")
-                        }
+                        child.classList.add("miss")
                     }
                 })
             },

--- a/src/glob-tool/templates/examples.vue
+++ b/src/glob-tool/templates/examples.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -17,37 +17,142 @@ limitations under the License.
 <template>
     <p>
         <b>{{ i18n.templates.examples.title }}</b>
-        <a class="jump-link" @click="set('*.js', ['one.js', 'two.js', 'three.js'])">
+
+        <a class="jump-link" @click="set('*.js', [
+            '// These will match as they end with \'.js\'',
+            'one.js',
+            'two.js',
+            'three.js',
+            '// This won\'t match as it doesn\'t end with \'.js\'',
+            'four.md'
+        ])"
+        >
             {{ i18n.templates.examples.zeroOrMoreChars }} <code class="slim">*</code>
         </a>
-        <a class="jump-link" @click="set('?.js', ['a.js', 'b.js', 'file.js'])">
+
+        <a class="jump-link" @click="set('?.js', [
+            '// These will match as they are a single character ending with \'.js\'',
+            'a.js',
+            'b.js',
+            '// This won\'t match as it is more than one character before \'.js\'',
+            'file.js'
+        ])"
+        >
             {{ i18n.templates.examples.oneChar }} <code class="slim">?</code>
         </a>
-        <a class="jump-link" @click="set('/**/*.js', ['/file.js', '/one/file.js', '/one/two/file.js', '/one/two/three/file.js'])">
+
+        <a class="jump-link" @click="set('/**/*.js', [
+            '// These will all match as the globstar matches zero or more directories recursively',
+            '/file.js',
+            '/one/file.js',
+            '/one/two/file.js',
+            '/one/two/three/file.js'
+        ])"
+        >
             {{ i18n.templates.examples.recursive }} <code class="slim">**</code>
         </a>
-        <a class="jump-link" @click="set('/{static,build/public}/*.js', ['/static/file.js', '/build/public/file.js', '/src/file.js'])">
+
+        <a class="jump-link" @click="set('/{static,build/public}/*.js', [
+            '// These will match as their directories are included in the group',
+            '/static/file.js',
+            '/build/public/file.js',
+            '// This won\'t match as the \'src\' directory is not in the group',
+            '/src/file.js'
+        ])"
+        >
             {{ i18n.templates.examples.list }} <code class="slim">{a,b,c}</code>
         </a>
-        <a class="jump-link" @click="set('/[abc]-xyz/*.js', ['/a-xyz/file.js', '/b-xyz/file.js', '/c-xyz/file.js', '/d-xyz/file.js'])">
+
+        <a class="jump-link" @click="set('/[abc]-xyz/*.js', [
+            '// These will match as they are in the range provided',
+            '/a-xyz/file.js',
+            '/b-xyz/file.js',
+            '/c-xyz/file.js',
+            '// This won\'t match as \'d\' is not in the range \'[abc]\'',
+            '/d-xyz/file.js'
+        ])"
+        >
             {{ i18n.templates.examples.range }} <code class="slim">[abc]</code>
         </a>
-        <a class="jump-link" @click="set('/[!abc]-xyz/*.js', ['/d-xyz/file.js', '/e-xyz/file.js', '/a-xyz/file.js', '/b-xyz/file.js', '/c-xyz/file.js'])">
+
+        <a class="jump-link" @click="set('/[!abc]-xyz/*.js', [
+            '// These will match as they are not in the given range',
+            '/d-xyz/file.js',
+            '/e-xyz/file.js',
+            '// This won\'t match as they are within the excluded range',
+            '/a-xyz/file.js',
+            '/b-xyz/file.js',
+            '/c-xyz/file.js'
+        ])"
+        >
             {{ i18n.templates.examples.notRange }} <code class="slim">[!abc]</code>
         </a>
-        <a class="jump-link" @click="set('/!(src|build)/*.js', ['/public/file.js', '/dist/file.js', '/src/file.js', '/build/file.js'])">
+
+        <a class="jump-link" @click="set('/!(src|build)/*.js', [
+            '// These will match as they are not in the excluded pattern',
+            '/public/file.js',
+            '/dist/file.js',
+            '// This won\'t match as they are in the directories that match the pattern',
+            '/src/file.js',
+            '/build/file.js'
+        ])"
+        >
             {{ i18n.templates.examples.notPatterns }} <code class="slim">!(a|b)</code>
         </a>
-        <a class="jump-link" @click="set('file?(.min|.umd).js', ['file.js', 'file.min.js', 'file.umd.js', 'file.min.umd.js', 'file.es6.js'])">
+
+        <a class="jump-link" @click="set('file?(.min|.umd).js', [
+            '// These all match as they have zero or one part from the pattern',
+            'file.js',
+            'file.min.js',
+            'file.umd.js',
+            '// This won\'t match as it has more than one parts from the pattern',
+            'file.min.umd.js',
+            '// This won\'t match as \'.es6\' is not in the pattern',
+            'file.es6.js'
+        ])"
+        >
             {{ i18n.templates.examples.zeroOrOnePattern }} <code class="slim">?(a|b)</code>
         </a>
-        <a class="jump-link" @click="set('file*(.min|.umd).js', ['file.js', 'file.min.js', 'file.umd.js', 'file.min.umd.js', 'file.es6.js'])">
+
+        <a class="jump-link" @click="set('file*(.min|.umd).js', [
+            '// These all match as they have zero or more parts from the pattern',
+            'file.js',
+            'file.min.js',
+            'file.umd.js',
+            'file.min.umd.js',
+            '// This won\'t match as \'.es6\' is not in the pattern',
+            'file.es6.js'
+        ])"
+        >
             {{ i18n.templates.examples.zeroOrMorePatterns }} <code class="slim">*(a|b)</code>
         </a>
-        <a class="jump-link" @click="set('file+(.min|.umd).js', ['file.min.js', 'file.umd.js', 'file.min.umd.js', 'file.es6.js', 'file.js'])">
+
+        <a class="jump-link" @click="set('file+(.min|.umd).js', [
+            '// These all match as they have one or more parts from the pattern',
+            'file.min.js',
+            'file.umd.js',
+            'file.min.umd.js',
+            '// This won\'t match as it has no part from the pattern',
+            'file.js',
+            '// This won\'t match as \'.es6\' is not in the pattern',
+            'file.es6.js'
+        ])"
+        >
             {{ i18n.templates.examples.oneOrMorePatterns }} <code class="slim">+(a|b)</code>
         </a>
-        <a class="jump-link" @click="set('file@(.min|.umd).js', ['file.min.js', 'file.umd.js', 'file.min.umd.js', 'file.es6.js', 'file.js'])">
+
+        <a class="jump-link" @click="set('file@(.min|.umd).js', [
+            '// These match as they have exactly one part from the pattern',
+            'file.min.js',
+            'file.umd.js',
+            '// This won\'t match as it more than one part from the pattern',
+            'file.min.umd.js',
+            '// This won\'t match as it has no part from the pattern',
+            'file.js',
+            '// This won\'t match as \'.es6\' is not in the pattern',
+            'file.es6.js'
+        ])"
+        >
             {{ i18n.templates.examples.exactlyOnePattern }} <code class="slim">@(a|b)</code>
         </a>
     </p>


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue, TS, SASS

## What issue does this relate to?

Resolves #11 

### What should this PR do?

Adds the ability to have comments within the test strings:

![image](https://user-images.githubusercontent.com/12371363/76569005-ff146a00-64a9-11ea-961d-ca2f4574460d.png)

### What are the acceptance criteria?

 - Comments enabled checkbox syncs with `comments` query parameter in the URL:
   - Clicking the checkbox updates the URL
   - Setting `true`/`false` in the URL is reflected correctly in the tool
 - With comments enabled, any line starting with `//` in the test strings is stylised as a comment (grey, smaller text)
 - With comments disabled, any line starting with `//` is treated like any other line
 - Each of the glob example links that we have at the top behave with the following:
   - Clicking on any forces comments to be enabled
   - All examples now include explainer comments