### PR TITLE
Import NPM package as test strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2214,12 +2214,35 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
-    "block-stream": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
-      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+    "bl": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+      "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
       "requires": {
-        "inherits": "~2.0.0"
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "bluebird": {
@@ -2724,17 +2747,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
     },
     "console-browserify": {
       "version": "1.2.0",
@@ -3502,17 +3514,6 @@
         "readable-stream": "^2.0.2"
       }
     },
-    "duplexify": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
-      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
-      "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
-      }
-    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3573,14 +3574,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
       "integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ=="
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -4196,11 +4189,6 @@
         "flat-cache": "^2.0.1"
       }
     },
-    "file-type": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
-      "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
-    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -4316,6 +4304,11 @@
         "js-yaml": "^3.4.6"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs-extra": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
@@ -4337,17 +4330,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
       "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
       "optional": true
-    },
-    "fstream": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "inherits": "~2.0.0",
-        "mkdirp": ">=0.5 0",
-        "rimraf": "2"
-      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -4483,36 +4465,6 @@
       "requires": {
         "brfs": "^1.2.0",
         "unicode-trie": "^0.3.1"
-      }
-    },
-    "gunzip-maybe": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
-      "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
-      "requires": {
-        "browserify-zlib": "^0.1.4",
-        "is-deflate": "^1.0.0",
-        "is-gzip": "^1.0.0",
-        "peek-stream": "^1.1.0",
-        "pumpify": "^1.3.3",
-        "through2": "^2.0.3"
-      },
-      "dependencies": {
-        "browserify-zlib": {
-          "version": "0.1.4",
-          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
-          "requires": {
-            "pako": "~0.2.0"
-          },
-          "dependencies": {
-            "pako": {
-              "version": "0.2.9",
-              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-              "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
-            }
-          }
-        }
       }
     },
     "har-schema": {
@@ -5050,11 +5002,6 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
-    "is-deflate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
-      "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
-    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -5099,11 +5046,6 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
-    },
-    "is-gzip": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
-      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
     },
     "is-html": {
       "version": "1.1.0",
@@ -5521,15 +5463,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
-    },
-    "memory-fs": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "requires": {
-        "errno": "^0.1.3",
-        "readable-stream": "^2.0.1"
-      }
     },
     "merge": {
       "version": "1.2.1",
@@ -6222,16 +6155,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "peek-stream": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
-      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "duplexify": "^3.5.0",
-        "through2": "^2.0.3"
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -6784,11 +6707,6 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -6811,25 +6729,6 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
-      }
-    },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "pumpify": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
-      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
-      "requires": {
-        "duplexify": "^3.6.0",
-        "inherits": "^2.0.3",
-        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -7450,6 +7349,20 @@
             "table": "^3.7.8",
             "text-table": "~0.2.0",
             "user-home": "^2.0.0"
+          },
+          "dependencies": {
+            "concat-stream": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+              "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+              "dev": true,
+              "requires": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
+              }
+            }
           }
         },
         "espree": {
@@ -8102,6 +8015,17 @@
         "through2": "~2.0.3"
       },
       "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
         "escodegen": {
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
@@ -8146,11 +8070,6 @@
         "to-arraybuffer": "^1.0.0",
         "xtend": "^4.0.0"
       }
-    },
-    "stream-shift": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
-      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
     },
     "strict-uri-encode": {
       "version": "2.0.0",
@@ -8296,14 +8215,28 @@
         "string-width": "^3.0.0"
       }
     },
-    "tar": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
-      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+    "tar-stream": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
+      "integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
       "requires": {
-        "block-stream": "*",
-        "fstream": "^1.0.12",
-        "inherits": "2"
+        "bl": "^4.0.1",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "terser": {
@@ -8716,18 +8649,6 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
-      }
-    },
-    "untar-memory": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/untar-memory/-/untar-memory-1.2.0.tgz",
-      "integrity": "sha1-Kc1SJfnF5vOVOXfHqXrJKV7rYPg=",
-      "requires": {
-        "concat-stream": "^1.5.2",
-        "file-type": "^4.0.0",
-        "gunzip-maybe": "^1.3.1",
-        "memory-fs": "^0.4.1",
-        "tar": "^2.2.1"
       }
     },
     "upath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2214,6 +2214,14 @@
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
       "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
     },
+    "block-stream": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+      "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
+      "requires": {
+        "inherits": "~2.0.0"
+      }
+    },
     "bluebird": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -3494,6 +3502,17 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -3537,6 +3556,14 @@
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
       "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
@@ -3546,6 +3573,14 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.0.tgz",
       "integrity": "sha512-jDgnJaF/Btomk+m3PZDTTCb5XIIIX3zYItnCRfF73zVgvinLoRomuhi75Y4su0PtQxWz4v66XnLLckyvyJTOIQ=="
+    },
+    "errno": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "requires": {
+        "prr": "~1.0.1"
+      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -4161,6 +4196,11 @@
         "flat-cache": "^2.0.1"
       }
     },
+    "file-type": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-4.4.0.tgz",
+      "integrity": "sha1-G2AOX8ofvcboDApwxxyNul95BsU="
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -4298,6 +4338,17 @@
       "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -4432,6 +4483,36 @@
       "requires": {
         "brfs": "^1.2.0",
         "unicode-trie": "^0.3.1"
+      }
+    },
+    "gunzip-maybe": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/gunzip-maybe/-/gunzip-maybe-1.4.1.tgz",
+      "integrity": "sha512-qtutIKMthNJJgeHQS7kZ9FqDq59/Wn0G2HYCRNjpup7yKfVI6/eqwpmroyZGFoCYaG+sW6psNVb4zoLADHpp2g==",
+      "requires": {
+        "browserify-zlib": "^0.1.4",
+        "is-deflate": "^1.0.0",
+        "is-gzip": "^1.0.0",
+        "peek-stream": "^1.1.0",
+        "pumpify": "^1.3.3",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "browserify-zlib": {
+          "version": "0.1.4",
+          "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+          "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+          "requires": {
+            "pako": "~0.2.0"
+          },
+          "dependencies": {
+            "pako": {
+              "version": "0.2.9",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+              "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+            }
+          }
+        }
       }
     },
     "har-schema": {
@@ -4969,6 +5050,11 @@
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
     },
+    "is-deflate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-deflate/-/is-deflate-1.0.0.tgz",
+      "integrity": "sha1-yGKQHDwWH7CdrHzcfnhPgOmPLxQ="
+    },
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
@@ -5013,6 +5099,11 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-gzip": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz",
+      "integrity": "sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM="
     },
     "is-html": {
       "version": "1.1.0",
@@ -5430,6 +5521,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
       "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA=="
+    },
+    "memory-fs": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+      "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+      "requires": {
+        "errno": "^0.1.3",
+        "readable-stream": "^2.0.1"
+      }
     },
     "merge": {
       "version": "1.2.1",
@@ -5940,9 +6040,9 @@
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pako": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
-      "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parcel-bundler": {
       "version": "1.12.4",
@@ -6120,6 +6220,16 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "peek-stream": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/peek-stream/-/peek-stream-1.1.3.tgz",
+      "integrity": "sha512-FhJ+YbOSBb9/rIl2ZeE/QHEsWn7PqNYt8ARAY3kIgNGOk13g9FGyIY6JIl/xB/3TFRVoTv5as0l11weORrTekA==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "duplexify": "^3.5.0",
+        "through2": "^2.0.3"
       }
     },
     "performance-now": {
@@ -6674,6 +6784,11 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "prr": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -6696,6 +6811,25 @@
         "parse-asn1": "^5.0.0",
         "randombytes": "^2.0.1",
         "safe-buffer": "^5.1.2"
+      }
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "pumpify": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+      "requires": {
+        "duplexify": "^3.6.0",
+        "inherits": "^2.0.3",
+        "pump": "^2.0.0"
       }
     },
     "punycode": {
@@ -8013,6 +8147,11 @@
         "xtend": "^4.0.0"
       }
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "strict-uri-encode": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
@@ -8155,6 +8294,16 @@
         "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
+      }
+    },
+    "tar": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+      "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
+      "requires": {
+        "block-stream": "*",
+        "fstream": "^1.0.12",
+        "inherits": "2"
       }
     },
     "terser": {
@@ -8492,6 +8641,13 @@
       "requires": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
+      },
+      "dependencies": {
+        "pako": {
+          "version": "0.2.9",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+          "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU="
+        }
       }
     },
     "union-value": {
@@ -8560,6 +8716,18 @@
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
           "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
         }
+      }
+    },
+    "untar-memory": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/untar-memory/-/untar-memory-1.2.0.tgz",
+      "integrity": "sha1-Kc1SJfnF5vOVOXfHqXrJKV7rYPg=",
+      "requires": {
+        "concat-stream": "^1.5.2",
+        "file-type": "^4.0.0",
+        "gunzip-maybe": "^1.3.1",
+        "memory-fs": "^0.4.1",
+        "tar": "^2.2.1"
       }
     },
     "upath": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,13 @@
     "babel-polyfill": "^6.26.0",
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
     "do-vue": "git+https://github.com/do-community/do-vue.git",
+    "node-fetch": "^2.6.0",
+    "pako": "^1.0.11",
     "parcel-bundler": "^1.12.4",
     "pretty-checkbox-vue": "^1.1.9",
     "query-string": "^6.12.1",
     "tree-parse": "0.0.5",
+    "untar-memory": "^1.2.0",
     "vue": "^2.6.11",
     "vue-hot-reload-api": "^2.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "parcel-bundler": "^1.12.4",
     "pretty-checkbox-vue": "^1.1.9",
     "query-string": "^6.12.1",
+    "tar-stream": "^2.1.2",
     "tree-parse": "0.0.5",
-    "untar-memory": "^1.2.0",
     "vue": "^2.6.11",
     "vue-hot-reload-api": "^2.3.3"
   },

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -175,19 +175,25 @@ $header: #0071fe;
 
       .modal-card-body {
         .columns {
+          max-height: 100%;
           margin: 0;
 
-          .title {
-            small {
-              font-size: .65em;
+          .column {
+            max-height: 100%;
+            overflow: auto;
+
+            .title {
+              small {
+                font-size: .65em;
+              }
             }
-          }
 
-          pre {
-            padding: 0;
+            pre {
+              padding: 0;
 
-            textarea {
-              background: transparent;
+              textarea {
+                background: transparent;
+              }
             }
           }
         }

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -175,8 +175,8 @@ $header: #0071fe;
 
       .modal-card-body {
         .columns {
-          max-height: 100%;
           margin: 0;
+          max-height: 100%;
 
           .column {
             max-height: 100%;

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -166,7 +166,7 @@ $header: #0071fe;
     }
   }
 
-  .tree-import {
+  .import-modal {
     .modal-card {
       @extend .container;
 

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -73,11 +73,13 @@ limitations under the License.
                     {{ i18n.templates.app.comments }}
                 </PrettyCheck>
 
-                <a class="button is-primary is-small" @click="showTree">Import tree command output</a>
+                <a class="button is-primary is-small" @click="showTree">Import tree command</a>
+                <a class="button is-primary is-small" @click="showPackage">Import NPM package</a>
             </div>
 
             <Help></Help>
-            <Tree ref="tree" @save="addTree"></Tree>
+            <Tree ref="tree" @save="addImport"></Tree>
+            <Package ref="package" @save="addImport"></Package>
         </div>
 
         <Footer :text="i18n.templates.app.oss"></Footer>
@@ -94,6 +96,7 @@ limitations under the License.
     import Examples from "./examples"
     import Help from "./help"
     import Tree from "./tree"
+    import Package from "./package"
 
     export default {
         name: "App",
@@ -104,6 +107,7 @@ limitations under the License.
             Examples,
             Help,
             Tree,
+            Package,
         },
         data() {
             return {
@@ -332,9 +336,12 @@ limitations under the License.
             showTree() {
                 this.$refs.tree.open()
             },
-            addTree(tests) {
+            showPackage() {
+                this.$refs.package.open()
+            },
+            addImport(tests, type) {
                 // If comments enabled, leave a comment
-                if (this.$data.commentsEnabled) tests.unshift("// Imported from tree command")
+                if (this.$data.commentsEnabled) tests.unshift(`// Imported from ${type}`)
 
                 // Add each of the new test strings
                 for (const line of tests) {
@@ -346,7 +353,7 @@ limitations under the License.
 
                 // Run a check
                 this.test()
-            }
+            },
         },
     }
 </script>

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -73,8 +73,10 @@ limitations under the License.
                     {{ i18n.templates.app.comments }}
                 </PrettyCheck>
 
-                <a class="button is-primary is-small" @click="showTree">Import tree command</a>
-                <a class="button is-primary is-small" @click="showPackage">Import NPM package</a>
+                <div>
+                    <a class="button is-primary is-small" @click="showTree">Import tree command</a>
+                    <a class="button is-primary is-small" @click="showPackage">Import NPM package</a>
+                </div>
             </div>
 
             <Help></Help>

--- a/src/glob-tool/templates/package.vue
+++ b/src/glob-tool/templates/package.vue
@@ -22,19 +22,21 @@ limitations under the License.
                     NPM package name:
                 </h3>
                 <div class="input-container">
-                    <i class="fas fa-circle-notch fa-spin" v-if="updating"></i>
-                    <i class="fas fa-box-open" v-else></i>
+                    <i v-if="updating" class="fas fa-circle-notch fa-spin"></i>
+                    <i v-else class="fas fa-box-open"></i>
                     <input ref="package"
                            v-model.trim.lazy="package"
                            class="input"
                            type="text"
                            placeholder="vue"
-                           :disabled="updating" />
+                           :disabled="updating"
+                    />
                 </div>
 
-                <a class="button is-primary"
+                <a v-if="!updating && !error && package.length && parsed.length"
+                   class="button is-primary"
                    @click="save"
-                   v-if="!updating && !error && package.length && parsed.length">
+                >
                     Import files as test strings
                 </a>
             </div>
@@ -68,10 +70,10 @@ limitations under the License.
 </template>
 
 <script>
-    import { inflate } from "pako";
-    import { Readable } from "stream";
-    import fetch from "node-fetch";
-    import untarToMemory from "untar-memory";
+    import { inflate } from "pako"
+    import { Readable } from "stream"
+    import fetch from "node-fetch"
+    import untarToMemory from "untar-memory"
     import Modal from "do-vue/src/templates/modal"
 
     export default {
@@ -89,46 +91,46 @@ limitations under the License.
         },
         watch: {
             package() {
-                this.$data.updating = true;
+                this.$data.updating = true
                 this.update()
             },
         },
         methods: {
             walk(fs, dir) {
-                const files = fs.readdirSync(dir);
-                const results = [];
+                const files = fs.readdirSync(dir)
+                const results = []
                 files.forEach(file => {
                     if (fs.statSync(dir + file).isDirectory()) {
-                        results.push(...this.walk(fs, dir + file + '/'))
+                        results.push(...this.walk(fs, dir + file + "/"))
                     } else {
-                        results.push(dir + file);
+                        results.push(dir + file)
                     }
-                });
-                return results;
+                })
+                return results
             },
             async update() {
-                if (!this.$data.package.length) return;
+                if (!this.$data.package.length) return
 
                 try {
                     // Get the tarball URL
-                    const data = await (await fetch(`https://cors-anywhere.herokuapp.com/https://registry.npmjs.com/${this.$data.package}`)).json();
-                    const tarUrl = data.versions[data['dist-tags'].latest].dist.tarball;
+                    const data = await (await fetch(`https://cors-anywhere.herokuapp.com/https://registry.npmjs.com/${this.$data.package}`)).json()
+                    const tarUrl = data.versions[data["dist-tags"].latest].dist.tarball
 
                     // Get the tarball contents
-                    const tarRes = await fetch(`https://cors-anywhere.herokuapp.com/${tarUrl}`);
-                    const tar = inflate(await tarRes.arrayBuffer());
+                    const tarRes = await fetch(`https://cors-anywhere.herokuapp.com/${tarUrl}`)
+                    const tar = inflate(await tarRes.arrayBuffer())
 
                     // Parse the tarball to an fs
-                    const tarStream = new Readable();
-                    tarStream.push(tar);
-                    tarStream.push(null);
-                    const memFs = await untarToMemory(tarStream);
+                    const tarStream = new Readable()
+                    tarStream.push(tar)
+                    tarStream.push(null)
+                    const memFs = await untarToMemory(tarStream)
 
                     // Get all files in fs
-                    this.$data.parsed = this.walk(memFs, '/').map(x => x.substr('/package/'.length));
+                    this.$data.parsed = this.walk(memFs, "/").map(x => x.substr("/package/".length))
                     this.$data.error = false
                 } catch (e) {
-                    console.error(e);
+                    console.error(e)
                     this.$data.parsed = []
                     this.$data.error = true
                 }

--- a/src/glob-tool/templates/package.vue
+++ b/src/glob-tool/templates/package.vue
@@ -149,10 +149,8 @@ limitations under the License.
             },
             open() {
                 this.$refs.modal.open()
-                this.update() // Ensure we're showing the parsed data for what's in the textarea
 
                 this.$nextTick(() => {
-                    this.$refs.package.dispatchEvent(new Event("input")) // Convince autoresize something happened
                     this.$nextTick(() => this.$refs.package.focus())
                 })
             },

--- a/src/glob-tool/templates/package.vue
+++ b/src/glob-tool/templates/package.vue
@@ -46,7 +46,7 @@ limitations under the License.
                     Files in package:
                 </h3>
                 <p v-if="updating">
-                     {{ updating }}
+                    {{ updating }}
                 </p>
                 <p v-else-if="error">
                     Sorry, an error occurred when trying to load files from the NPM package.
@@ -98,8 +98,8 @@ limitations under the License.
         methods: {
             untar(stream) {
                 return new Promise((resolve, reject) => {
-                    const paths = [];
-                    const extractHandler = extract();
+                    const paths = []
+                    const extractHandler = extract()
 
                     extractHandler.on("entry", (header, stream, next) => {
                         if (header.type === "file")
@@ -134,7 +134,7 @@ limitations under the License.
                     const tarStream = new Readable()
                     tarStream.push(tar)
                     tarStream.push(null)
-                    const files = await this.untar(tarStream);
+                    const files = await this.untar(tarStream)
 
                     // We're done
                     this.$data.parsed = files.map(x => x.substr("package/".length))

--- a/src/glob-tool/templates/tree.vue
+++ b/src/glob-tool/templates/tree.vue
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 
 <template>
-    <Modal ref="modal" title="Import tree command" class="tree-import">
+    <Modal ref="modal" title="Import tree command" class="import-modal">
         <div class="columns">
             <div class="column">
                 <h3 class="title is-4">

--- a/src/glob-tool/templates/tree.vue
+++ b/src/glob-tool/templates/tree.vue
@@ -112,7 +112,7 @@ limitations under the License.
                 })
             },
             save() {
-                this.$emit("save", this.$data.parsed, 'tree command')
+                this.$emit("save", this.$data.parsed, "tree command")
                 this.$refs.modal.close()
             },
         }


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue, SASS

## What issue does this relate to?

N/A

### What should this PR do?

Adds the ability to import the files in an NPM package as test strings.

**This is currently using the CORS bypass applet due to the NPM registry API not having permissive CORS. Not sure what we want to do about this?**

### What are the acceptance criteria?

 - Pressing the import NPM package button opens the modal
 - Entering a package name results in the files being shown
 - Pressing import as test strings inserts those files into the test strings