### PR TITLE
Add option to only show matches

### DIFF
--- a/src/glob-tool/i18n/en/templates/app.ts
+++ b/src/glob-tool/i18n/en/templates/app.ts
@@ -6,5 +6,8 @@ export default {
     testsSubtitle: "Enter strings here to test against the glob",
     comments: "Comments enabled? (Start a line with '//' to write a comment when enabled)",
     matches: "Show matches only?",
+    hidden: ["test", "that didn't match", "is", "are", "hidden"],
+    importTree: "Import tree command",
+    importNPM: "Import NPM package",
     oss: "This tool is {link|open-source on GitHub|https://github.com/do-community/glob-tool} under the {link|Apache-2.0|https://github.com/do-community/glob-tool/blob/master/LICENSE} license! We welcome feedback and contributions.",
 } as {[key: string]: string}

--- a/src/glob-tool/i18n/en/templates/app.ts
+++ b/src/glob-tool/i18n/en/templates/app.ts
@@ -10,4 +10,4 @@ export default {
     importTree: "Import tree command",
     importNPM: "Import NPM package",
     oss: "This tool is {link|open-source on GitHub|https://github.com/do-community/glob-tool} under the {link|Apache-2.0|https://github.com/do-community/glob-tool/blob/master/LICENSE} license! We welcome feedback and contributions.",
-} as {[key: string]: string}
+} as {[key: string]: string | string[]}

--- a/src/glob-tool/i18n/en/templates/app.ts
+++ b/src/glob-tool/i18n/en/templates/app.ts
@@ -5,5 +5,6 @@ export default {
     tests: "Test strings",
     testsSubtitle: "Enter strings here to test against the glob",
     comments: "Comments enabled? (Start a line with '//' to write a comment when enabled)",
+    matches: "Show matches only?",
     oss: "This tool is {link|open-source on GitHub|https://github.com/do-community/glob-tool} under the {link|Apache-2.0|https://github.com/do-community/glob-tool/blob/master/LICENSE} license! We welcome feedback and contributions.",
 } as {[key: string]: string}

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -50,6 +50,12 @@ $header: #0071fe;
         box-shadow: inset ($margin * 1.5 + $icon-width) 0 darken($panel, 5%);
         padding: ($margin / 2) $margin ($margin / 2) $left;
 
+        &.matches-only {
+          .miss {
+            display: none;
+          }
+        }
+
         > div {
           font-size: 16px;
           line-height: 21px;
@@ -94,6 +100,15 @@ $header: #0071fe;
             font-size: 14px;
           }
         }
+      }
+    }
+
+    p {
+      &.matches-only {
+        color: $muted;
+        font-style: italic;
+        font-size: .9em;
+        margin: -$margin 0 0;
       }
     }
 

--- a/src/glob-tool/scss/style.scss
+++ b/src/glob-tool/scss/style.scss
@@ -106,8 +106,8 @@ $header: #0071fe;
     p {
       &.matches-only {
         color: $muted;
-        font-style: italic;
         font-size: .9em;
+        font-style: italic;
         margin: -$margin 0 0;
       }
     }

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -242,8 +242,8 @@ limitations under the License.
                 this.store(glob, children)
 
                 // Run the hit/miss check
-                this.$data.hits = 0;
-                this.$data.misses = 0;
+                this.$data.hits = 0
+                this.$data.misses = 0
                 children.forEach(child => {
                     // Remove all classes to start
                     child.classList.remove("miss")
@@ -263,10 +263,10 @@ limitations under the License.
 
                     // If a match, add hit, else add miss
                     if (minimatch(child.textContent, glob)) {
-                        this.$data.hits += 1;
+                        this.$data.hits += 1
                         child.classList.add("hit")
                     } else {
-                        this.$data.misses += 1;
+                        this.$data.misses += 1
                         child.classList.add("miss")
                     }
                 })

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -54,7 +54,7 @@ limitations under the License.
             </h2>
             <div class="input-container">
                 <div ref="textarea"
-                     class="textarea input"
+                     :class="`textarea input${matchesOnly ? ' matches-only' : ''}`"
                      contenteditable="true"
                      @keydown="down"
                      @keyup="up"
@@ -66,11 +66,24 @@ limitations under the License.
                     <div>/test/some/globs</div>
                 </div>
             </div>
+            <p class="matches-only">
+                <template v-if="matchesOnly">
+                    {{ misses.toLocaleString() }} test{{ misses === 1 ? '' : 's' }} that didn't match
+                    {{ misses === 1 ? 'is' : 'are' }} hidden.
+                </template>
+                <template v-else>
+                    &nbsp;
+                </template>
+            </p>
 
             <div class="actions-container">
                 <PrettyCheck v-model="commentsEnabled" class="p-default p-curve p-fill p-icon">
                     <i slot="extra" class="icon fas fa-check"></i>
                     {{ i18n.templates.app.comments }}
+                </PrettyCheck>
+                <PrettyCheck v-model="matchesOnly" class="p-default p-curve p-fill p-icon">
+                    <i slot="extra" class="icon fas fa-check"></i>
+                    {{ i18n.templates.app.matches }}
                 </PrettyCheck>
 
                 <div>
@@ -116,6 +129,9 @@ limitations under the License.
                 i18n,
                 shiftActive: false,
                 commentsEnabled: null,
+                matchesOnly: null,
+                hits: 0,
+                misses: 0,
             }
         },
         watch: {
@@ -147,8 +163,14 @@ limitations under the License.
                 this.$data.commentsEnabled = !(comments.toString().toLowerCase() === "false")
                 this.test()
             },
+            setMatches(matches) {
+                // Explicit true, otherwise false
+                this.$data.matchesOnly = (matches.toString().toLowerCase() === "true")
+                this.test()
+            },
             set(glob, tests) {
                 this.$data.commentsEnabled = true
+                this.$data.matchesOnly = false
                 this.setGlob(glob)
                 this.setTests(tests)
             },
@@ -157,12 +179,14 @@ limitations under the License.
                 if (parsed.glob) this.setGlob(parsed.glob)
                 if (parsed.tests) this.setTests(parsed.tests)
                 this.setComments(parsed.comments || "true") // Default comments to enabled
+                this.setMatches(parsed.matches || "false") // Default matches only to disabled
             },
             store(glob, tests) {
                 const parsed = queryString.parse(window.location.search)
                 parsed.glob = glob
                 parsed.tests = tests.map(x => x.textContent).filter(x => !!x.trim())
                 if (this.$data.commentsEnabled !== null) parsed.comments = this.$data.commentsEnabled
+                if (this.$data.matchesOnly !== null) parsed.matches = this.$data.matchesOnly
                 window.history.pushState({}, "", `?${queryString.stringify(parsed)}`)
             },
             empty() {
@@ -217,13 +241,15 @@ limitations under the License.
                 this.store(glob, children)
 
                 // Run the hit/miss check
+                this.$data.hits = 0;
+                this.$data.misses = 0;
                 children.forEach(child => {
                     // Remove all classes to start
                     child.classList.remove("miss")
                     child.classList.remove("hit")
                     child.classList.remove("comment")
 
-                    // If blank, ddo nothing more
+                    // If blank, do nothing more
                     if (child.textContent.trim() === "") {
                         return
                     }
@@ -236,8 +262,10 @@ limitations under the License.
 
                     // If a match, add hit, else add miss
                     if (minimatch(child.textContent, glob)) {
+                        this.$data.hits += 1;
                         child.classList.add("hit")
                     } else {
+                        this.$data.misses += 1;
                         child.classList.add("miss")
                     }
                 })

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -68,8 +68,9 @@ limitations under the License.
             </div>
             <p class="matches-only">
                 <template v-if="matchesOnly">
-                    {{ misses.toLocaleString() }} test{{ misses === 1 ? '' : 's' }} that didn't match
-                    {{ misses === 1 ? 'is' : 'are' }} hidden.
+                    {{ misses.toLocaleString() }} {{ i18n.templates.app.hidden[0] }}{{ misses === 1 ? '' : 's' }}
+                    {{ i18n.templates.app.hidden[1] }} {{ i18n.templates.app.hidden[misses === 1 ? 2 : 3] }}
+                    {{ i18n.templates.app.hidden[4] }}.
                 </template>
                 <template v-else>
                     &nbsp;
@@ -87,8 +88,8 @@ limitations under the License.
                 </PrettyCheck>
 
                 <div>
-                    <a class="button is-primary is-small" @click="showTree">Import tree command</a>
-                    <a class="button is-primary is-small" @click="showPackage">Import NPM package</a>
+                    <a class="button is-primary is-small" @click="showTree">{{ i18n.templates.app.importTree }}</a>
+                    <a class="button is-primary is-small" @click="showPackage">{{ i18n.templates.app.importNPM }}</a>
                 </div>
             </div>
 


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue, TS, SASS

## What issue does this relate to?

N/A

### What should this PR do?

Adds an option to the tool to only show matches for the current glob in the test strings section.
When enabled, it will show a message beneath with how many tests are hidden due to not matching.

### What are the acceptance criteria?

Toggle works correctly & my implementation of i18n string data for this makes sense.