### PR TITLE
Add support for query parameter compression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5433,6 +5433,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "lzutf8": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/lzutf8/-/lzutf8-0.5.5.tgz",
+      "integrity": "sha512-x4AdRtP0ETRe0BW8V+TfW+8rOF5t3vWU/Z52twUqDRf0OiEuXiLvXNN6Zm8biFCTI9ffXBZb++THAjfkJ559Nw=="
+    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-polyfill": "^6.26.0",
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
     "do-vue": "git+https://github.com/do-community/do-vue.git",
+    "lzutf8": "^0.5.5",
     "node-fetch": "^2.6.0",
     "pako": "^1.0.11",
     "parcel-bundler": "^1.12.4",

--- a/src/glob-tool/templates/help.vue
+++ b/src/glob-tool/templates/help.vue
@@ -88,20 +88,20 @@ limitations under the License.
             </li>
         </ul>
 
-        <h3 id="using-the-tool-programatically">
-            Using the tool programatically
+        <h3 id="using-the-tool-programmatically">
+            Using the tool programmatically
         </h3>
         <p>
             All options for the tool are stored in URL query parameters, which allows for easy programmatic generation
-            of a glob test page. The glob string is stored in the <code class="slim">glob</code> query parameter. The
-            test strings are stored in the <code class="slim">tests</code> query parameter, with one parameter per test
-            string.
+            of a glob test page. The glob string is stored in the <code class="slim">glob</code> query parameter, with
+            the test strings being stored in the <code class="slim">tests</code> query parameter, one parameter per test
+            string. Eg. <code class="slim">glob=*.js&tests=hello.js&tests=hello.md</code>.
         </p>
         <p>
             The settings are also stored in the query parameters, with the comments enabled setting being controlled via
-            the <code class="slim">comments</code> query parameter (<code class="slim">true</code> or
+            the <code class="slim">comments</code> query param (<code class="slim">true</code> or
             <code class="slim">false</code>). Similarly, the show matches only setting is set with the
-            <code class="slim">matches</code> query parameter.
+            <code class="slim">matches</code> query param. Eg. <code class="slim">comments=true&matches=false</code>.
         </p>
         <p>
             If you're generating a long URI (> 2000 chars), it may be advisable to compress it to avoid a 414 request

--- a/src/glob-tool/templates/help.vue
+++ b/src/glob-tool/templates/help.vue
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019 DigitalOcean
+Copyright 2020 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,14 +16,18 @@ limitations under the License.
 
 <template>
     <div class="help">
-        <h3>What are globs?</h3>
+        <h3 id="what-are-globs">
+            What are globs?
+        </h3>
         <p>
             Globs are the patterns you use when you run commands such as <code class="slim">ls src/*.js</code>, or you
             might see them used in config files such as a <code class="slim">.gitignore</code> where you might see
             <code class="slim">.cache/*</code>, for example.
         </p>
 
-        <h3>What can you use in them?</h3>
+        <h3 id="what-can-you-use">
+            What can you use in them?
+        </h3>
         <p>
             Alongside plaintext, globs have a set of control (or special) characters that allow them to become far more
             powerful that just some boring old text.
@@ -83,6 +87,45 @@ limitations under the License.
                 subdirectories. This allows for recursive directory searching easily.
             </li>
         </ul>
+
+        <h3 id="using-the-tool-programatically">
+            Using the tool programatically
+        </h3>
+        <p>
+            All options for the tool are stored in URL query parameters, which allows for easy programmatic generation
+            of a glob test page. The glob string is stored in the <code class="slim">glob</code> query parameter. The
+            test strings are stored in the <code class="slim">tests</code> query parameter, with one parameter per test
+            string.
+        </p>
+        <p>
+            The settings are also stored in the query parameters, with the comments enabled setting being controlled via
+            the <code class="slim">comments</code> query parameter (<code class="slim">true</code> or
+            <code class="slim">false</code>). Similarly, the show matches only setting is set with the
+            <code class="slim">matches</code> query parameter.
+        </p>
+        <p>
+            If you're generating a long URI (> 2000 chars), it may be advisable to compress it to avoid a 414 request
+            URI too long error. We support compressed URL parameters using the following technique:
+        </p>
+        <ol>
+            <li>
+                Generate your initial URL parameters as normal (without the leading ?), eg.
+                <code class="slim">glob=*.js&tests=hello.js&tests=hello.md</code>.
+            </li>
+            <li>
+                Use the <a href="https://www.npmjs.com/package/lzutf8" target="_blank" rel="noopener">lzutf8</a> library
+                to compress that string to a new base64 string, eg.
+                <code class="slim">lzutf8.compress('glob=*.js&tests=hello.js&tests=hello.md', { outputEncoding: 'Base64' })</code>
+                <i class="fas fa-long-arrow-alt-right"></i>
+                <code class="slim">Z2xvYj0qLmpzJnRlc3RzPWhlbGxv0A9tZA==</code>
+            </li>
+            <li>
+                Set the URL query parameter <code class="slim">c</code> to this compressed string, eg.
+                <code class="slim">`?c=${encodeURIComponent('Z2xvYj0qLmpzJnRlc3RzPWhlbGxv0A9tZA==')}`</code>
+                <i class="fas fa-long-arrow-alt-right"></i>
+                <code class="slim">?c=Z2xvYj0qLmpzJnRlc3RzPWhlbGxv0A9tZA%3D%3D</code>
+            </li>
+        </ol>
     </div>
 </template>
 


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue

## What issue does this relate to?

https://github.com/cdnjs/packages/pull/154

### What should this PR do?

Fixes an issue where a long set of test strings would result in the generated URI being too long, causing a 414 request URI too long error if the page was refreshed.

This implements query parameter compression once the query params reach 2000 chars, as well as adding information to the tool about setting query parameters yourself including using compression.

### What are the acceptance criteria?

 - With a short set of test strings, the tool behaves as normal with query parameters.
 - Once enough test strings are present, the tool will switch to using compressed query parameters.
 - Reloading the tool page with compressed query parameters works correctly, loading the tool state from the compressed parameters.
 - Programmatic usage instructions on the tool make sense and are technically correct.