### PR TITLE
Remove lzutf8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7048,11 +7048,6 @@
         "yallist": "^2.1.2"
       }
     },
-    "lzutf8": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/lzutf8/-/lzutf8-0.5.6.tgz",
-      "integrity": "sha512-nZT9HP+xe9FxhRj0DIHb/7jVeFdIQkOul8ebCYc5bMevmuzZZYbsjwFlg+UfO8GTQMfiGU2Fyt8JXtffeKF0Kg=="
-    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-polyfill": "^6.26.0",
     "do-bulma": "git+https://github.com/do-community/do-bulma.git",
     "do-vue": "git+https://github.com/do-community/do-vue.git",
-    "lzutf8": "^0.5.6",
     "node-fetch": "^2.6.1",
     "pako": "^1.0.11",
     "parcel-bundler": "^1.12.4",

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -202,8 +202,11 @@ limitations under the License.
                 if (this.$data.matchesOnly !== null) parsed.matches = this.$data.matchesOnly
 
                 const query = queryString.stringify(parsed)
-                window.history.pushState({}, "",
-                    `${window.location.pathname}${query.length > 4000 ? '#' : ''}${query.length ? '?' : ''}${query}`)
+                window.history.pushState(
+                    {},
+                    "",
+                    `${window.location.pathname}${query.length > 4000 ? "#" : ""}${query.length ? "?" : ""}${query}`
+                )
             },
             empty() {
                 // Ensure no lost brs

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -105,7 +105,6 @@ limitations under the License.
 <script>
     import minimatch from "minimatch"
     import queryString from "query-string"
-    import LZUTF8 from "lzutf8"
     import PrettyCheck from "pretty-checkbox-vue/check"
     import i18n from "../i18n"
     import Header from "do-vue/src/templates/header"
@@ -185,9 +184,8 @@ limitations under the License.
                 this.setTests(tests)
             },
             parseUri() {
-                const parsed = queryString.parse(window.location.search)
-                if (parsed.c) return queryString.parse(LZUTF8.decompress(parsed.c, { inputEncoding: "Base64" }))
-                return parsed
+                const query = window.location.search || window.location.hash.slice(1)
+                return queryString.parse(query)
             },
             load() {
                 const parsed = this.parseUri()
@@ -204,17 +202,8 @@ limitations under the License.
                 if (this.$data.matchesOnly !== null) parsed.matches = this.$data.matchesOnly
 
                 const query = queryString.stringify(parsed)
-                if (query.length <= 2000) {
-                    window.history.pushState({}, "", `?${query}`)
-                    return
-                }
-
-                const compressed = queryString.stringify({ c: LZUTF8.compress(query, { outputEncoding: "Base64" }) })
-                console.info(`Compressing query params to reduce URI length: ${query.length.toLocaleString()} -> ${compressed.length.toLocaleString()}`)
-                if (compressed.length > 2000) {
-                    console.warn("URI is too long with compressed query params")
-                }
-                window.history.pushState({}, "", `?${compressed}`)
+                window.history.pushState({}, "",
+                    `${window.location.pathname}${query.length > 4000 ? '#' : ''}${query.length ? '?' : ''}${query}`)
             },
             empty() {
                 // Ensure no lost brs

--- a/src/glob-tool/templates/help.vue
+++ b/src/glob-tool/templates/help.vue
@@ -104,28 +104,10 @@ limitations under the License.
             <code class="slim">matches</code> query param. Eg. <code class="slim">comments=true&matches=false</code>.
         </p>
         <p>
-            If you're generating a long URI (> 2000 chars), it may be advisable to compress it to avoid a 414 request
-            URI too long error. We support compressed URL parameters using the following technique:
+            If you're generating a long URI (> 4000 chars), it may be advisable to prefix the query string with a hash
+            (<code class="slim">#</code>) to avoid a 414 request URI too long error. E.g.
+            <code class="slim">#?glob=*.js&tests=hello.js&tests=hello.md</code>.
         </p>
-        <ol>
-            <li>
-                Generate your initial URL parameters as normal (without the leading ?), eg.
-                <code class="slim">glob=*.js&tests=hello.js&tests=hello.md</code>.
-            </li>
-            <li>
-                Use the <a href="https://www.npmjs.com/package/lzutf8" target="_blank" rel="noopener">lzutf8</a> library
-                to compress that string to a new base64 string, eg.
-                <code class="slim">lzutf8.compress('glob=*.js&tests=hello.js&tests=hello.md', { outputEncoding: 'Base64' })</code>
-                <i class="fas fa-long-arrow-alt-right"></i>
-                <code class="slim">Z2xvYj0qLmpzJnRlc3RzPWhlbGxv0A9tZA==</code>
-            </li>
-            <li>
-                Set the URL query parameter <code class="slim">c</code> to this compressed string, eg.
-                <code class="slim">`?c=${encodeURIComponent('Z2xvYj0qLmpzJnRlc3RzPWhlbGxv0A9tZA==')}`</code>
-                <i class="fas fa-long-arrow-alt-right"></i>
-                <code class="slim">?c=Z2xvYj0qLmpzJnRlc3RzPWhlbGxv0A9tZA%3D%3D</code>
-            </li>
-        </ol>
     </div>
 </template>
 


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue
- **Something else:** Deps

## What issue does this relate to?

N/A

### What should this PR do?

Remove the use of lzutf8 and the compressed query param solution; instead, using the hash which keeps the query params client-side.

### What are the acceptance criteria?

- A short set of test strings are kept in the query params directly.
- Adding more test strings cleanly switch the query params to being prefixed with a hash.
- Reloading the page with query params including the hash prefix loads the strings correctly into the tool.
