### PR TITLE
Switch to cors.bridged.cc to proxy NPM registry

### DIFF
--- a/src/glob-tool/templates/package.vue
+++ b/src/glob-tool/templates/package.vue
@@ -121,12 +121,12 @@ limitations under the License.
                 try {
                     // Get the tarball URL
                     this.$data.updating = "Fetching package information from NPM..."
-                    const data = await (await fetch(`https://cors-anywhere.herokuapp.com/https://registry.npmjs.com/${this.$data.package}`)).json()
+                    const data = await (await fetch(`https://cors.bridged.cc/https://registry.npmjs.com/${this.$data.package}`)).json()
                     const tarUrl = data.versions[data["dist-tags"].latest].dist.tarball
 
                     // Get the tarball contents
                     this.$data.updating = "Downloading the contents of the package..."
-                    const tarRes = await fetch(`https://cors-anywhere.herokuapp.com/${tarUrl}`)
+                    const tarRes = await fetch(`https://cors.bridged.cc/${tarUrl}`)
                     const tar = inflate(await tarRes.arrayBuffer())
 
                     // Parse the tarball to an fs


### PR DESCRIPTION
## Type of Change

- **Tool Source:** NPM import

## What issue does this relate to?

N/A

### What should this PR do?

Replaces the CORS proxy being used for interacting with the NPM registry as the previous one no longer functions.

### What are the acceptance criteria?

Using the NPM import functionality in the tool works correctly, e.g. typing `tree-parse` in the NPM import modal shows the package files as expected.