### PR TITLE
Remove CORS proxy for NPM registry calls

### DIFF
--- a/src/glob-tool/templates/package.vue
+++ b/src/glob-tool/templates/package.vue
@@ -116,27 +116,19 @@ limitations under the License.
                     stream.pipe(extractHandler)
                 })
             },
-            fetchCors(url) {
-                return fetch(`https://cors.bridged.cc/${url}`, {
-                    method: "GET",
-                    headers: {
-                        "x-cors-grida-api-key": process.env.CORS_API_KEY
-                    },
-                })
-            },
             async update() {
                 if (!this.$data.package.length) return
 
                 try {
                     // Get the tarball URL
                     this.$data.updating = "Fetching package information from NPM..."
-                    const data = await this.fetchCors(`https://registry.npmjs.com/${this.$data.package}`)
+                    const data = await fetch(`https://registry.npmjs.com/${this.$data.package}`)
                         .then(res => res.json())
                     const tarUrl = data.versions[data["dist-tags"].latest].dist.tarball
 
                     // Get the tarball contents
                     this.$data.updating = "Downloading the contents of the package..."
-                    const tarRes = await this.fetchCors(tarUrl)
+                    const tarRes = await fetch(tarUrl)
                     const tar = inflate(await tarRes.arrayBuffer())
 
                     // Parse the tarball to an fs


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Vue (NPM fetching)

## What issue does this relate to?

[N/A](https://github.com/npm/feedback/discussions/117#discussioncomment-2691120)

### What should this PR do?

NPM recently added ACAO headers to NPM registry API endpoints, which allows us to remove our dependency on an intermediary proxy to import package files for the tool.

### What are the acceptance criteria?

NPM imports work, and make calls directly to the NPM registry rather than through a proxy.