### PR TITLE
Add 'dot' match option

### DIFF
--- a/src/glob-tool/i18n/en/templates/app.ts
+++ b/src/glob-tool/i18n/en/templates/app.ts
@@ -6,6 +6,7 @@ export default {
     testsSubtitle: "Enter strings here to test against the glob",
     comments: "Comments enabled? (Start a line with '//' to write a comment when enabled)",
     matches: "Show matches only?",
+    matchOptionDot: "Wildcards match path segments starting with a dot",
     hidden: ["test", "that didn't match", "is", "are", "hidden"],
     importTree: "Import tree command",
     importNPM: "Import NPM package",


### PR DESCRIPTION
Manually integration-tested including loading from & saving to URL querystring

## Type of Change
<!-- What part of the source are you modifying? Remove the irrelevant options. -->

- **Tool Source:** Vue (app.vue), i18n
## What issue does this relate to?
Resolves #54 

### What should this PR do?
Adds "matchOptions" object to Vue app with (for the time being) a single option: dot (mirroring minimatch's).
Loads the option from & saves it to the URL querystring (as `options=dot:true`)
Also sets up foundation for adding support for other minimatch options

### What are the acceptance criteria?
Please check the translation.

| before | after |
|----------| --------|
|![Imgur](https://i.imgur.com/dzJCpvR.png) | ![Imgur](https://i.imgur.com/l9gjpNe.png) | |
