### PR TITLE
Fix browser history writing

### DIFF
--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -150,6 +150,7 @@ limitations under the License.
                 },
                 hits: 0,
                 misses: 0,
+                storeDebounce: null,
             }
         },
         watch: {
@@ -232,18 +233,21 @@ limitations under the License.
                 this.setMatches(parsed.matches || "false") // Default matches only to disabled
             },
             store(glob, tests) {
-                const parsed = this.parseUri()
-                parsed.glob = glob
-                parsed.tests = tests.map(x => x.textContent).filter(x => !!x.trim())
-                parsed.options = []
-                if (this.$data.commentsEnabled !== null) parsed.comments = this.$data.commentsEnabled
-                if (this.$data.matchesOnly !== null) parsed.matches = this.$data.matchesOnly
-                if (this.$data.matchOptions.dot) parsed.options.push("dot:true")
+                if (this.storeDebounce) clearTimeout(this.storeDebounce)
+                this.storeDebounce = setTimeout(() => {
+                    const parsed = this.parseUri()
+                    parsed.glob = glob
+                    parsed.tests = tests.map(x => x.textContent).filter(x => !!x.trim())
+                    parsed.options = []
+                    if (this.$data.commentsEnabled !== null) parsed.comments = this.$data.commentsEnabled
+                    if (this.$data.matchesOnly !== null) parsed.matches = this.$data.matchesOnly
+                    if (this.$data.matchOptions.dot) parsed.options.push("dot:true")
 
-                const query = queryString.stringify(parsed)
-                const url = `${window.location.pathname}${query.length > 4000 ? "#" : ""}${query.length ? "?" : ""}${query}`
-                if (url !== `${window.location.pathname}${window.location.search}${window.location.hash}`)
-                    window.history.pushState({}, "", url)
+                    const query = queryString.stringify(parsed)
+                    const url = `${window.location.pathname}${query.length > 4000 ? "#" : ""}${query.length ? "?" : ""}${query}`
+                    if (url !== `${window.location.pathname}${window.location.search}${window.location.hash}`)
+                        window.history.pushState({}, "", url)
+                }, 50)
             },
             empty() {
                 // Ensure no lost brs

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -241,11 +241,9 @@ limitations under the License.
                 if (this.$data.matchOptions.dot) parsed.options.push("dot:true")
 
                 const query = queryString.stringify(parsed)
-                window.history.pushState(
-                    {},
-                    "",
-                    `${window.location.pathname}${query.length > 4000 ? "#" : ""}${query.length ? "?" : ""}${query}`
-                )
+                const url = `${window.location.pathname}${query.length > 4000 ? "#" : ""}${query.length ? "?" : ""}${query}`
+                if (url !== `${window.location.pathname}${window.location.search}${window.location.hash}`)
+                    window.history.pushState({}, "", url)
             },
             empty() {
                 // Ensure no lost brs

--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -246,7 +246,7 @@ limitations under the License.
                     const query = queryString.stringify(parsed)
                     const url = `${window.location.pathname}${query.length > 4000 ? "#" : ""}${query.length ? "?" : ""}${query}`
                     if (url !== `${window.location.pathname}${window.location.search}${window.location.hash}`)
-                        window.history.pushState({}, "", url)
+                        window.history.replaceState({}, "", url)
                 }, 50)
             },
             empty() {


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Store method

## What issue does this relate to?

Resolves #69 

### What should this PR do?

Updates how we store the tool state in the browser history, so that we're not writing on every Vue state change, and so we're replacing the existing state instead of continually pushing new entries.

### What are the acceptance criteria?

History writes are denounced so rapid Vue state updates don't cause multiple writes, and history writes are done by replacing the existing state instead of pushing a new history item, allowing the back button to work effectively to leave the page.