### PR TITLE
Trim carriage returns from tests

### DIFF
--- a/src/glob-tool/templates/app.vue
+++ b/src/glob-tool/templates/app.vue
@@ -276,6 +276,13 @@ limitations under the License.
                         child.parentElement.removeChild(child)
                     }
                 }
+
+                // If we have any lines that end with a carriage return, remove it
+                for (const child of this.$refs.textarea.children) {
+                    if (child.textContent.endsWith("\r")) {
+                        child.textContent = child.textContent.slice(0, -1)
+                    }
+                }
             },
             focus() {
                 // If we're focused in the textarea, focus on first div instead


### PR DESCRIPTION
## Type of Change

- **Tool Source:** Test standardisation

## What issue does this relate to?

Resolves #78

### What should this PR do?

Trims carriage returns from the end of tests, fixing false negative matches on Windows devices.

### What are the acceptance criteria?

Any tests that contain carriage returns at the end have them stripped, ensuring false negatives due to them do not happen.